### PR TITLE
feat(users): add new fields and tracks table

### DIFF
--- a/backend/db/migrate/20250905052457_add_oauth_fields_to_users.rb
+++ b/backend/db/migrate/20250905052457_add_oauth_fields_to_users.rb
@@ -1,0 +1,5 @@
+class AddOauthFieldsToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :provider, :string
+  end
+end

--- a/backend/db/migrate/20250905060205_add_bio_to_users.rb
+++ b/backend/db/migrate/20250905060205_add_bio_to_users.rb
@@ -1,0 +1,5 @@
+class AddBioToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :bio, :text
+  end
+end

--- a/backend/db/migrate/20250905060355_add_uid_to_users.rb
+++ b/backend/db/migrate/20250905060355_add_uid_to_users.rb
@@ -1,0 +1,5 @@
+class AddUidToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :uid, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,13 +10,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_08_20_030443) do
+ActiveRecord::Schema[7.0].define(version: 2025_09_05_060355) do
   create_table "jwt_denylists", force: :cascade do |t|
     t.string "jti"
     t.datetime "exp"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["jti"], name: "index_jwt_denylists_on_jti"
+  end
+
+  create_table "tracks", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "title"
+    t.text "description"
+    t.string "yt_url"
+    t.float "bpm"
+    t.string "key"
+    t.string "genre"
+    t.text "ai_text"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "created_at"], name: "index_tracks_on_user_id_and_created_at"
+    t.index ["user_id", "yt_url"], name: "index_tracks_on_user_id_and_yt_url", unique: true
+    t.index ["user_id"], name: "index_tracks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -28,8 +44,12 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_030443) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
+    t.string "provider"
+    t.text "bio"
+    t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "tracks", "users"
 end

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'new attributes' do
+    it 'can save with provider and uid' do
+      user = User.create!(
+        email: 'github@example.com',
+        password: 'password123',
+        provider: 'github',
+        uid: '12345'
+      )
+      expect(user.provider).to eq('github')
+      expect(user.uid).to eq('12345')
+    end
+
+    it 'can save with bio' do
+      user = User.create!(
+        email: 'bio@example.com',
+        password: 'password123',
+        bio: 'I am a musician'
+      )
+      expect(user.bio).to eq('I am a musician')
+    end
+
+    it 'allows nil values for new fields' do
+      user = User.create!(
+        email: 'normal@example.com',
+        password: 'password123'
+      )
+      expect(user.provider).to be_nil
+      expect(user.uid).to be_nil
+      expect(user.bio).to be_nil
+    end
+
+    it 'can save all new attributes together' do
+      user = User.create!(
+        email: 'complete@example.com',
+        password: 'password123',
+        provider: 'github',
+        uid: '67890',
+        bio: 'Full stack musician and developer'
+      )
+      expect(user.provider).to eq('github')
+      expect(user.uid).to eq('67890')
+      expect(user.bio).to eq('Full stack musician and developer')
+    end
+  end
+end


### PR DESCRIPTION
- ユーザーモデルに新しい属性（provider, bio, uid）を追加
- tracksテーブルを新規作成し、ユーザーとの関連付けを追加
- 新しい属性に対するRSpecテストを作成し、保存機能を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Profiles now include an optional Bio field you can add or edit.
  - Accounts can store external provider details (provider, UID) for connecting third-party accounts; these fields are optional and do not affect existing users.

- Tests
  - Added coverage to ensure the new profile and account fields save correctly, allow empty values, and work together without issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->