### PR TITLE
fix: resolve audio file re-upload reflection issue

### DIFF
--- a/backend/app/controllers/api/v1/tracks_controller.rb
+++ b/backend/app/controllers/api/v1/tracks_controller.rb
@@ -9,8 +9,10 @@ class Api::V1::TracksController < ApplicationController
     audio_file = params[:audio_file]
     
     if audio_file
-      # 一時ファイル保存
-      temp_path = Rails.root.join('tmp', 'uploads', audio_file.original_filename)
+      # 一時ファイル保存（タイムスタンプ付きで重複回避）
+      timestamp = Time.current.strftime("%Y%m%d_%H%M%S_%L")
+      filename = "#{timestamp}_#{audio_file.original_filename}"
+      temp_path = Rails.root.join('tmp', 'uploads', filename)
       FileUtils.mkdir_p(File.dirname(temp_path))
       File.write(temp_path, audio_file.read, mode: 'wb')
       

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -12,10 +12,16 @@ export default function Page() {
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
+      // 前のBlobURLをクリーンアップ
+      if (audioUrl) {
+        URL.revokeObjectURL(audioUrl);
+      }
+
       setAudioFile(file);
       const url = URL.createObjectURL(file);
       setAudioUrl(url);
-      // データは解析後まで保持する
+      // 前の解析結果をクリア
+      setAnalysisResult(null);
     }
   };
 


### PR DESCRIPTION
Fixes audio file re-upload caching conflicts by adding timestamp-based filenames and proper blob URL cleanup.