### PR TITLE
feat: add navigation link to matching page

### DIFF
--- a/frontend/src/app/__tests__/page.test.tsx
+++ b/frontend/src/app/__tests__/page.test.tsx
@@ -23,4 +23,13 @@ describe("HomePage", () => {
     expect(screen.getByText("佐藤 花子")).toBeInTheDocument();
     expect(screen.getByText("鈴木 一郎")).toBeInTheDocument();
   });
+
+  it("renders matching link", () => {
+    render(<HomePage />);
+
+    const matchingLink = screen.getByRole("link", {
+      name: /企業向けマッチング/,
+    });
+    expect(matchingLink).toHaveAttribute("href", "/matching");
+  });
 });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -58,12 +58,20 @@ export default function HomePage() {
           <Link href="/" className="text-2xl font-bold text-gray-900">
             Music Portfolio
           </Link>
-          <Link
-            href="/upload"
-            className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg transition-colors duration-200"
-          >
-            楽曲アップロード
-          </Link>
+          <div className="flex gap-4 items-center">
+            <Link
+              href="/matching"
+              className="text-gray-600 hover:text-gray-900 px-4 py-2 transition-colors duration-200"
+            >
+              企業向けマッチング
+            </Link>
+            <Link
+              href="/upload"
+              className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg transition-colors duration-200"
+            >
+              楽曲アップロード
+            </Link>
+          </div>
         </nav>
       </header>
 


### PR DESCRIPTION
- Add 'Enterprise Matching' link in homepage header
- Add test for matching navigation link
- Improve header navigation layout with flex container

🤖 Generated with [Claude Code](https://claude.com/claude-code)