### PR TITLE
feat: add TypeScript types for Track and User

### DIFF
--- a/frontend/src/types/__tests__/index.test.ts
+++ b/frontend/src/types/__tests__/index.test.ts
@@ -1,0 +1,140 @@
+import type {
+  User,
+  Track,
+  TracksListResponse,
+  TrackDetailResponse,
+  ApiErrorResponse,
+} from "../index";
+
+describe("TypeScript Type Definitions", () => {
+  describe("User type", () => {
+    it("should accept valid user object", () => {
+      const user: User = {
+        id: 1,
+        email: "test@example.com",
+        name: "Test User",
+        bio: "Test bio",
+      };
+
+      expect(user.id).toBe(1);
+      expect(user.email).toBe("test@example.com");
+      expect(user.name).toBe("Test User");
+      expect(user.bio).toBe("Test bio");
+    });
+
+    it("should accept user without optional bio", () => {
+      const user: User = {
+        id: 1,
+        email: "test@example.com",
+        name: "Test User",
+      };
+
+      expect(user.bio).toBeUndefined();
+    });
+  });
+
+  describe("Track type", () => {
+    it("should accept valid track object", () => {
+      const track: Track = {
+        id: 1,
+        title: "Test Track",
+        description: "Test description",
+        yt_url: "https://www.youtube.com/watch?v=test123",
+        bpm: 120,
+        key: "C",
+        genre: "Rock",
+        ai_text: "AI generated text",
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-02T00:00:00Z",
+        user: {
+          id: 1,
+          email: "test@example.com",
+          name: "Test User",
+        },
+      };
+
+      expect(track.id).toBe(1);
+      expect(track.title).toBe("Test Track");
+      expect(track.user.name).toBe("Test User");
+    });
+
+    it("should accept track with minimal required fields", () => {
+      const track: Track = {
+        id: 1,
+        title: "Test Track",
+        yt_url: "https://www.youtube.com/watch?v=test123",
+        created_at: "2025-01-01T00:00:00Z",
+        user: {
+          id: 1,
+          email: "test@example.com",
+          name: "Test User",
+        },
+      };
+
+      expect(track.description).toBeUndefined();
+      expect(track.bpm).toBeUndefined();
+      expect(track.key).toBeUndefined();
+      expect(track.genre).toBeUndefined();
+    });
+  });
+
+  describe("TracksListResponse type", () => {
+    it("should accept valid tracks list response", () => {
+      const response: TracksListResponse = {
+        tracks: [
+          {
+            id: 1,
+            title: "Track 1",
+            yt_url: "https://www.youtube.com/watch?v=test1",
+            created_at: "2025-01-01T00:00:00Z",
+            user: {
+              id: 1,
+              email: "user1@example.com",
+              name: "User 1",
+            },
+          },
+        ],
+        pagination: {
+          current_page: 1,
+          total_pages: 1,
+          total_count: 1,
+          per_page: 10,
+        },
+      };
+
+      expect(response.tracks).toHaveLength(1);
+      expect(response.pagination.current_page).toBe(1);
+    });
+  });
+
+  describe("TrackDetailResponse type", () => {
+    it("should accept valid track detail response", () => {
+      const response: TrackDetailResponse = {
+        track: {
+          id: 1,
+          title: "Test Track",
+          yt_url: "https://www.youtube.com/watch?v=test123",
+          created_at: "2025-01-01T00:00:00Z",
+          user: {
+            id: 1,
+            email: "test@example.com",
+            name: "Test User",
+          },
+        },
+      };
+
+      expect(response.track.id).toBe(1);
+      expect(response.track.title).toBe("Test Track");
+    });
+  });
+
+  describe("ApiErrorResponse type", () => {
+    it("should accept valid error response", () => {
+      const response: ApiErrorResponse = {
+        error: "Something went wrong",
+      };
+
+      expect(response.error).toBe("Something went wrong");
+    });
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,53 @@
+/**
+ * User型定義
+ */
+export type User = {
+  id: number;
+  email: string;
+  name: string;
+  bio?: string;
+};
+
+/**
+ * Track型定義
+ */
+export type Track = {
+  id: number;
+  title: string;
+  description?: string;
+  yt_url: string;
+  bpm?: number;
+  key?: string;
+  genre?: string;
+  ai_text?: string;
+  created_at: string;
+  updated_at?: string;
+  user: User;
+};
+
+/**
+ * Tracks一覧取得APIのレスポンス型
+ */
+export type TracksListResponse = {
+  tracks: Track[];
+  pagination: {
+    current_page: number;
+    total_pages: number;
+    total_count: number;
+    per_page: number;
+  };
+};
+
+/**
+ * Track詳細取得APIのレスポンス型
+ */
+export type TrackDetailResponse = {
+  track: Track;
+};
+
+/**
+ * APIエラーレスポンス型
+ */
+export type ApiErrorResponse = {
+  error: string;
+};


### PR DESCRIPTION
## Summary
Add TypeScript type definitions for the music portfolio application.

## Changes
- ✅ Add `User` type definition
- ✅ Add `Track` type definition
- ✅ Add `TracksListResponse` type for API list response with pagination
- ✅ Add `TrackDetailResponse` type for API detail response
- ✅ Add `ApiErrorResponse` type for error handling
- ✅ Add comprehensive tests for type definitions

## Files Changed
- `frontend/src/types/index.ts` - Type definitions
- `frontend/src/types/__tests__/index.test.ts` - Type tests

## Impact
- New files only
- No impact on existing code

## Test Plan
- [x] Create TypeScript type definitions
- [x] Add type definition tests
- [ ] Run CI (GitHub Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)