### PR TITLE
feat: implement Jobs API endpoints

### DIFF
--- a/backend/app/controllers/api/v1/jobs_controller.rb
+++ b/backend/app/controllers/api/v1/jobs_controller.rb
@@ -1,0 +1,196 @@
+class Api::V1::JobsController < ApplicationController
+  skip_before_action :authenticate_user!, only: [:index, :show]
+
+  # GET /api/v1/jobs
+  def index
+    # ページネーション設定
+    page = params[:page]&.to_i || 1
+    per_page = params[:per_page]&.to_i || 10
+    per_page = [per_page, 50].min # 最大50件
+
+    # 公開中の案件のみ表示（認証なしの場合）
+    jobs = if current_user
+      # 認証済みユーザーは自分の全案件も表示
+      Job.includes(:client).where("status = 'published' OR client_id = ?", current_user.id)
+    else
+      Job.published.includes(:client)
+    end
+
+    # ソート（新しい順）
+    jobs = jobs.order(created_at: :desc)
+
+    # ページネーション適用
+    total_count = jobs.count
+    total_pages = (total_count.to_f / per_page).ceil
+    jobs = jobs.offset((page - 1) * per_page).limit(per_page)
+
+    # レスポンス生成
+    render json: {
+      jobs: jobs.map { |job| job_json(job) },
+      pagination: {
+        current_page: page,
+        total_pages: total_pages,
+        total_count: total_count,
+        per_page: per_page
+      }
+    }
+  end
+
+  # GET /api/v1/jobs/:uuid
+  def show
+    job = Job.includes(:client).find_by(uuid: params[:id])
+
+    if job.nil?
+      render json: { error: "案件が見つかりません" }, status: :not_found
+      return
+    end
+
+    # draft の場合は所有者のみ閲覧可能
+    if job.draft? && (!current_user || job.client_id != current_user.id)
+      render json: { error: "この案件にアクセスする権限がありません" }, status: :forbidden
+      return
+    end
+
+    render json: { job: job_json(job, detailed: true) }
+  end
+
+  # POST /api/v1/jobs
+  def create
+    job = current_user.jobs.build(job_params)
+
+    if job.save
+      render json: {
+        message: "案件を作成しました",
+        job: job_json(job)
+      }, status: :created
+    else
+      render json: {
+        error: job.errors.full_messages.join(", ")
+      }, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH /api/v1/jobs/:uuid
+  def update
+    job = Job.find_by(uuid: params[:id])
+
+    if job.nil?
+      render json: { error: "案件が見つかりません" }, status: :not_found
+      return
+    end
+
+    # 所有者チェック
+    unless job.client_id == current_user.id
+      render json: { error: "この案件を更新する権限がありません" }, status: :forbidden
+      return
+    end
+
+    if job.update(job_params)
+      render json: {
+        message: "案件を更新しました",
+        job: job_json(job)
+      }
+    else
+      render json: {
+        error: job.errors.full_messages.join(", ")
+      }, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /api/v1/jobs/:uuid
+  def destroy
+    job = Job.find_by(uuid: params[:id])
+
+    if job.nil?
+      render json: { error: "案件が見つかりません" }, status: :not_found
+      return
+    end
+
+    # 所有者チェック
+    unless job.client_id == current_user.id
+      render json: { error: "この案件を削除する権限がありません" }, status: :forbidden
+      return
+    end
+
+    job.destroy
+    render json: { message: "案件を削除しました" }
+  end
+
+  # POST /api/v1/jobs/:uuid/publish
+  def publish
+    job = Job.find_by(uuid: params[:id])
+
+    if job.nil?
+      render json: { error: "案件が見つかりません" }, status: :not_found
+      return
+    end
+
+    # 所有者チェック
+    unless job.client_id == current_user.id
+      render json: { error: "この案件を公開する権限がありません" }, status: :forbidden
+      return
+    end
+
+    # draft 以外は公開できない
+    unless job.draft?
+      render json: { error: "draft 状態の案件のみ公開できます" }, status: :unprocessable_entity
+      return
+    end
+
+    job.status = 'published'
+    job.published_at = Time.current
+
+    if job.save
+      render json: {
+        message: "案件を公開しました",
+        job: job_json(job)
+      }
+    else
+      render json: {
+        error: job.errors.full_messages.join(", ")
+      }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def job_params
+    params.require(:job).permit(
+      :title,
+      :description,
+      :budget_jpy,
+      :budget_min_jpy,
+      :budget_max_jpy,
+      :delivery_due_on,
+      :is_remote,
+      :location_note,
+      :track_id
+    )
+  end
+
+  def job_json(job, detailed: false)
+    base = {
+      uuid: job.uuid,
+      title: job.title,
+      description: job.description,
+      status: job.status,
+      budget_jpy: job.budget_jpy,
+      budget_min_jpy: job.budget_min_jpy,
+      budget_max_jpy: job.budget_max_jpy,
+      is_remote: job.is_remote,
+      published_at: job.published_at,
+      created_at: job.created_at
+    }
+
+    if detailed
+      base.merge!({
+        delivery_due_on: job.delivery_due_on,
+        location_note: job.location_note,
+        track_id: job.track_id,
+        updated_at: job.updated_at
+      })
+    end
+
+    base
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -7,6 +7,11 @@ Rails.application.routes.draw do
     namespace :v1 do
       resource :user, only: [:show, :update]
       resources :tracks
+      resources :jobs do
+        member do
+          post :publish
+        end
+      end
     end
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/backend/spec/controllers/api/v1/jobs_controller_spec.rb
+++ b/backend/spec/controllers/api/v1/jobs_controller_spec.rb
@@ -1,0 +1,356 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::JobsController, type: :controller do
+  let(:client_user) { User.create!(email: 'client@example.com', password: 'password123', name: 'Client User') }
+  let(:musician_user) { User.create!(email: 'musician@example.com', password: 'password123', name: 'Musician User') }
+
+  describe "GET #index" do
+    before do
+      # 公開案件
+      Job.create!(
+        client: client_user,
+        title: 'Public Job 1',
+        description: 'A public job description',
+        status: 'published',
+        published_at: Time.current,
+        budget_min_jpy: 10000,
+        budget_max_jpy: 50000
+      )
+      Job.create!(
+        client: client_user,
+        title: 'Public Job 2',
+        description: 'Another public job',
+        status: 'published',
+        published_at: Time.current,
+        budget_min_jpy: 20000,
+        budget_max_jpy: 100000
+      )
+      # Draft案件（公開されていない）
+      Job.create!(
+        client: client_user,
+        title: 'Draft Job',
+        description: 'A draft job',
+        status: 'draft',
+        budget_min_jpy: 5000,
+        budget_max_jpy: 10000
+      )
+    end
+
+    it "returns published jobs without authentication" do
+      get :index
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      expect(json["jobs"]).to be_an(Array)
+      expect(json["jobs"].length).to eq(2) # 公開案件のみ
+      expect(json["pagination"]).to be_present
+    end
+
+    it "includes pagination information" do
+      get :index
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      expect(json["pagination"]["current_page"]).to eq(1)
+      expect(json["pagination"]["total_count"]).to eq(2)
+      expect(json["pagination"]["per_page"]).to eq(10)
+    end
+
+    it "returns jobs ordered by created_at desc" do
+      get :index
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      titles = json["jobs"].map { |j| j["title"] }
+      expect(titles).to eq(['Public Job 2', 'Public Job 1']) # 新しい順
+    end
+
+    it "supports pagination with page and per_page parameters" do
+      get :index, params: { page: 1, per_page: 1 }
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      expect(json["jobs"].length).to eq(1)
+      expect(json["pagination"]["total_pages"]).to eq(2)
+    end
+
+    it "shows own draft jobs when authenticated" do
+      sign_in client_user
+      get :index
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      expect(json["jobs"].length).to eq(3) # 公開2件 + 自分のdraft1件
+    end
+  end
+
+  describe "GET #show" do
+    let(:published_job) do
+      Job.create!(
+        client: client_user,
+        title: 'Test Job',
+        description: 'Test description',
+        status: 'published',
+        published_at: Time.current,
+        budget_min_jpy: 10000,
+        budget_max_jpy: 50000
+      )
+    end
+
+    let(:draft_job) do
+      Job.create!(
+        client: client_user,
+        title: 'Draft Job',
+        description: 'Draft description',
+        status: 'draft',
+        budget_min_jpy: 5000,
+        budget_max_jpy: 10000
+      )
+    end
+
+    it "returns published job detail without authentication" do
+      get :show, params: { id: published_job.uuid }
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      expect(json["job"]["uuid"]).to eq(published_job.uuid)
+      expect(json["job"]["title"]).to eq('Test Job')
+    end
+
+    it "returns 403 for draft job without authentication" do
+      get :show, params: { id: draft_job.uuid }
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns draft job detail when authenticated as owner" do
+      sign_in client_user
+      get :show, params: { id: draft_job.uuid }
+      expect(response).to have_http_status(:ok)
+
+      json = JSON.parse(response.body)
+      expect(json["job"]["uuid"]).to eq(draft_job.uuid)
+    end
+
+    it "returns 403 for draft job when authenticated as non-owner" do
+      sign_in musician_user
+      get :show, params: { id: draft_job.uuid }
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns 404 for non-existent job" do
+      get :show, params: { id: 'non-existent-uuid' }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "POST #create" do
+    before do
+      sign_in client_user
+    end
+
+    it "creates a job with valid parameters" do
+      expect {
+        post :create, params: {
+          job: {
+            title: 'New Job',
+            description: 'New job description',
+            budget_min_jpy: 10000,
+            budget_max_jpy: 50000
+          }
+        }
+      }.to change(Job, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      json = JSON.parse(response.body)
+      expect(json["message"]).to eq("案件を作成しました")
+      expect(json["job"]["title"]).to eq('New Job')
+    end
+
+    it "returns error with invalid parameters" do
+      post :create, params: {
+        job: {
+          title: '',
+          description: ''
+        }
+      }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      json = JSON.parse(response.body)
+      expect(json["error"]).to be_present
+    end
+
+    it "requires authentication" do
+      sign_out client_user
+      post :create, params: {
+        job: {
+          title: 'New Job',
+          description: 'Description'
+        }
+      }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe "PATCH #update" do
+    let(:job) do
+      Job.create!(
+        client: client_user,
+        title: 'Original Title',
+        description: 'Original description',
+        status: 'draft',
+        budget_min_jpy: 10000,
+        budget_max_jpy: 50000
+      )
+    end
+
+    before do
+      sign_in client_user
+    end
+
+    it "updates job with valid parameters" do
+      patch :update, params: {
+        id: job.uuid,
+        job: { title: 'Updated Title' }
+      }
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["job"]["title"]).to eq('Updated Title')
+
+      job.reload
+      expect(job.title).to eq('Updated Title')
+    end
+
+    it "returns error with invalid parameters" do
+      patch :update, params: {
+        id: job.uuid,
+        job: { title: '' }
+      }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "returns 403 when updating as non-owner" do
+      sign_in musician_user
+      patch :update, params: {
+        id: job.uuid,
+        job: { title: 'Hacked Title' }
+      }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns 404 for non-existent job" do
+      patch :update, params: {
+        id: 'non-existent-uuid',
+        job: { title: 'Updated' }
+      }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "DELETE #destroy" do
+    let(:job) do
+      Job.create!(
+        client: client_user,
+        title: 'Job to Delete',
+        description: 'Will be deleted',
+        status: 'draft',
+        budget_min_jpy: 10000,
+        budget_max_jpy: 50000
+      )
+    end
+
+    before do
+      sign_in client_user
+    end
+
+    it "deletes job as owner" do
+      expect {
+        delete :destroy, params: { id: job.uuid }
+      }.to change(Job, :count).by(-1)
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["message"]).to eq("案件を削除しました")
+    end
+
+    it "returns 403 when deleting as non-owner" do
+      sign_in musician_user
+      expect {
+        delete :destroy, params: { id: job.uuid }
+      }.to_not change(Job, :count)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns 404 for non-existent job" do
+      delete :destroy, params: { id: 'non-existent-uuid' }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "POST #publish" do
+    let(:draft_job) do
+      Job.create!(
+        client: client_user,
+        title: 'Draft Job',
+        description: 'To be published',
+        status: 'draft',
+        budget_min_jpy: 10000,
+        budget_max_jpy: 50000
+      )
+    end
+
+    let(:published_job) do
+      Job.create!(
+        client: client_user,
+        title: 'Already Published',
+        description: 'Already published',
+        status: 'published',
+        published_at: Time.current,
+        budget_min_jpy: 10000,
+        budget_max_jpy: 50000
+      )
+    end
+
+    before do
+      sign_in client_user
+    end
+
+    it "publishes draft job" do
+      post :publish, params: { id: draft_job.uuid }
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["message"]).to eq("案件を公開しました")
+      expect(json["job"]["status"]).to eq('published')
+
+      draft_job.reload
+      expect(draft_job.status).to eq('published')
+      expect(draft_job.published_at).to be_present
+    end
+
+    it "returns error when publishing non-draft job" do
+      post :publish, params: { id: published_job.uuid }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      json = JSON.parse(response.body)
+      expect(json["error"]).to eq("draft 状態の案件のみ公開できます")
+    end
+
+    it "returns 403 when publishing as non-owner" do
+      sign_in musician_user
+      post :publish, params: { id: draft_job.uuid }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns 404 for non-existent job" do
+      post :publish, params: { id: 'non-existent-uuid' }
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Jobs APIの完全な実装を追加しました。Phase 4モデル（Job, Proposal, Contract, ContractMilestone）のうち、Jobsに関するRESTful APIエンドポイントを実装しています。

## Implemented Endpoints

### Jobs API
- `GET /api/v1/jobs` - 公開案件一覧（認証不要、認証済みユーザーは自分のdraft案件も表示）
- `GET /api/v1/jobs/:uuid` - 案件詳細（draftは所有者のみ閲覧可）
- `POST /api/v1/jobs` - 案件作成（要認証）
- `PATCH /api/v1/jobs/:uuid` - 案件更新（要認証・所有者のみ）
- `DELETE /api/v1/jobs/:uuid` - 案件削除（要認証・所有者のみ）
- `POST /api/v1/jobs/:uuid/publish` - 案件公開（要認証・所有者のみ）

## Features

### ✅ UUID対応
- UUIDを使ったリソース識別（`find_by_uuid`）
- セキュリティ向上（IDの推測不可）

### ✅ ページネーション
- デフォルト10件/ページ、最大50件/ページ
- total_count, total_pages, current_page, per_page を含むpagination情報

### ✅ 認証・認可
- Devise + JWT による認証
- 所有者チェック（update, destroy, publish）
- draft案件は所有者のみ閲覧可能

### ✅ 包括的なテスト
- Controller specs完備（全アクション網羅）
- 正常系・異常系・権限チェックのテストケース
- TracksControllerのテストパターンを踏襲

## Implementation Details

### Controller
- `app/controllers/api/v1/jobs_controller.rb` (196行)
- 既存のTracksControllerのパターンを踏襲
- 認証が必要なアクションは `skip_before_action :authenticate_user!` で制御
- エラーハンドリング（404 Not Found, 403 Forbidden, 422 Unprocessable Entity）

### Routes
- `resources :jobs` with `member { post :publish }`
- RESTful設計

### Tests
- `spec/controllers/api/v1/jobs_controller_spec.rb` (356行)
- 全エンドポイントのテストケース
- RSpecのControllerテスト形式

## Test Plan
- [x] ローカルでの実装完了
- [ ] CI（GitHub Actions）でのテスト実行
- [ ] 全テストグリーン確認

## Next Steps
次のPRで以下を実装予定：
1. Proposals API（提案管理）
2. Contracts API（契約管理）
3. Milestones API（マイルストーン管理）

🤖 Generated with [Claude Code](https://claude.com/claude-code)