### PR TITLE
feat: サインアップページを実装

### DIFF
--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3000";
+
+export default function SignupPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [name, setName] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    try {
+      const res = await fetch(`${API_BASE_URL}/auth/sign_up`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          user: {
+            email,
+            password,
+            name,
+          },
+        }),
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        const token = res.headers.get("Authorization");
+
+        if (token) {
+          localStorage.setItem("jwt", token);
+
+          if (data.user) {
+            localStorage.setItem("user", JSON.stringify(data.user));
+          }
+
+          router.push("/upload");
+        } else {
+          setError("認証トークンの取得に失敗しました");
+        }
+      } else {
+        const errorData = await res.json();
+        setError(errorData.error || "登録に失敗しました");
+      }
+    } catch (err) {
+      setError("ネットワークエラーが発生しました");
+      console.error("Signup error:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        <div className="bg-white shadow-md rounded-lg p-8">
+          <h1 className="text-2xl font-bold text-gray-900 mb-6 text-center">
+            新規登録
+          </h1>
+
+          {error && (
+            <div className="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded">
+              {error}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-1">
+                名前
+              </label>
+              <input
+                id="name"
+                type="text"
+                placeholder="山田太郎"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                required
+                disabled={loading}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+                メールアドレス
+              </label>
+              <input
+                id="email"
+                type="email"
+                placeholder="example@email.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                required
+                disabled={loading}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+                パスワード
+              </label>
+              <input
+                id="password"
+                type="password"
+                placeholder="パスワードを入力"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                required
+                disabled={loading}
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-md transition-colors duration-200 disabled:bg-gray-400 disabled:cursor-not-allowed"
+            >
+              {loading ? "登録中..." : "登録"}
+            </button>
+          </form>
+
+          <div className="mt-6 text-center">
+            <p className="text-sm text-gray-600">
+              すでにアカウントをお持ちの方は{" "}
+              <Link href="/login" className="text-blue-500 hover:text-blue-600 font-medium">
+                ログイン
+              </Link>
+            </p>
+          </div>
+
+          <div className="mt-4 text-center">
+            <Link href="/" className="text-sm text-gray-500 hover:text-gray-700">
+              ホームに戻る
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
新規ユーザー登録ページを実装

## Changes
- `frontend/src/app/signup/page.tsx`: サインアップページ作成
  - 名前、メールアドレス、パスワード入力フォーム
  - Rails API (`POST /auth/sign_up`) と連携
  - 登録成功後は `/upload` へリダイレクト
  - JWT トークンを localStorage に保存

## Test plan
- [x] `/signup` でページが表示される
- [x] ログインページへのリンクが動作する
- [ ] 全フィールド入力して登録ボタンをクリック
- [ ] 登録成功後に `/upload` へ遷移する

🤖 Generated with [Claude Code](https://claude.com/claude-code)