### PR TITLE
fix: JWTトークン期限切れによるアップロードエラーを修正

### DIFF
--- a/backend/config/initializers/devise.rb
+++ b/backend/config/initializers/devise.rb
@@ -322,7 +322,7 @@ Devise.setup do |config|
       ['POST', %r{^/auth$}]
     ]
     jwt.revocation_requests = [['DELETE', %r{^/auth/sign_out$}]]
-    jwt.expiration_time = 1.day.to_i
+    jwt.expiration_time = 30.days.to_i
     jwt.request_formats = { user: [:json] }
   end
 end

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -82,6 +82,12 @@ export default function UploadPage() {
         body: formData,
       });
 
+      if (res.status === 401) {
+        localStorage.removeItem("jwt");
+        window.location.href = "/login";
+        return;
+      }
+
       const data = await res.json();
 
       if (res.ok) {
@@ -119,6 +125,12 @@ export default function UploadPage() {
         },
         body: JSON.stringify({ yt_url: ytUrl, title: "YouTube Video" }),
       });
+
+      if (res.status === 401) {
+        localStorage.removeItem("jwt");
+        window.location.href = "/login";
+        return;
+      }
 
       const data = await res.json();
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -5,6 +5,13 @@ const API_URL =
     ? (process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000')
     : (process.env.NEXT_PUBLIC_API_URL || '');
 
+function handleSessionExpired(): void {
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem('jwt');
+    window.location.href = '/login';
+  }
+}
+
 async function parseResponse<T>(res: Response): Promise<T> {
   const text = await res.text();
   try {
@@ -31,6 +38,7 @@ export async function apiGet<T>(path: string, token?: string): Promise<T> {
   });
 
   if (res.status === 401) {
+    handleSessionExpired();
     throw new Error('ログインセッションが切れました。再度ログインしてください');
   }
 
@@ -55,6 +63,7 @@ export async function apiPost<T>(path: string, token: string, body?: unknown): P
   });
 
   if (res.status === 401) {
+    handleSessionExpired();
     throw new Error('ログインセッションが切れました。再度ログインしてください');
   }
 


### PR DESCRIPTION
## 問題
ログイン後数日経過した状態で楽曲アップロードを行うと「サーバーとの通信に失敗しました」エラーが発生する

## 原因
- JWTトークンの有効期限が1日に設定されていた
- アップロードページの直接fetch呼び出しで401レスポンスが適切に処理されていなかった
- 期限切れトークンで401が返った際、レスポンスbodyのJSONパースに失敗しcatch節の汎用エラーメッセージが表示されていた

## 修正内容
- JWT有効期限を1日→30日に延長 (`devise.rb`)
- APIクライアント (`client.ts`) に `handleSessionExpired()` を追加し、401時にトークン削除+ログイン画面リダイレクト
- アップロードページ (`upload/page.tsx`) の音声ファイル・YouTube両方のfetchに401ハンドリングを追加

## テスト計画
- [ ] ログイン後、楽曲アップロードが正常に動作すること
- [ ] 期限切れトークンで401が返った場合、ログイン画面にリダイレクトされること
- [ ] YouTube登録でも同様に401ハンドリングが動作すること