### PR TITLE
refactor: JWT管理をauth.tsに集約

### DIFF
--- a/frontend/src/app/jobs/[id]/proposals/page.tsx
+++ b/frontend/src/app/jobs/[id]/proposals/page.tsx
@@ -5,6 +5,7 @@ import { use, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
 import ProposalCard from '@/components/ProposalCard';
+import { getToken } from '@/lib/auth';
 
 interface Proposal {
   uuid: string;
@@ -35,7 +36,7 @@ export default function ProposalsPage({ params }: { params: Promise<{ id: string
   useEffect(() => {
     const fetchData = async () => {
       setError(null);
-      const token = localStorage.getItem('jwt');
+      const token = getToken();
       if (!token) return;
 
       try {

--- a/frontend/src/app/messages/[id]/page.tsx
+++ b/frontend/src/app/messages/[id]/page.tsx
@@ -7,6 +7,7 @@ import AuthGuard from '@/components/AuthGuard';
 import { useAsyncData } from '@/hooks/useAsyncData';
 import { fetchConversation } from '@/lib/api/conversations';
 import type { Conversation } from '@/types/conversation';
+import { getToken } from '@/lib/auth';
 
 export default function ConversationPage({
   params,
@@ -17,7 +18,7 @@ export default function ConversationPage({
 
   const { data: conversation, loading, error } = useAsyncData<Conversation>(
     () => {
-      const token = localStorage.getItem('jwt');
+      const token = getToken();
       if (!token) throw new Error('ログインが必要です');
       return fetchConversation(token, id);
     },

--- a/frontend/src/app/messages/page.tsx
+++ b/frontend/src/app/messages/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import AuthGuard from '@/components/AuthGuard';
 import { useUser } from '@/hooks/useUser';
 import { useChatList } from '@/hooks/useChatList';
+import { getToken } from '@/lib/auth';
 
 function formatDateTime(dateString: string): string {
   const date = new Date(dateString);
@@ -29,8 +30,7 @@ function formatDateTime(dateString: string): string {
 
 export default function MessagesPage() {
   const { isMusician } = useUser();
-  const token =
-    typeof window !== 'undefined' ? localStorage.getItem('jwt') : null;
+  const token = getToken();
   const { conversations, loading, error, retry } = useChatList(token);
 
   return (

--- a/frontend/src/app/musicians/[id]/page.tsx
+++ b/frontend/src/app/musicians/[id]/page.tsx
@@ -6,6 +6,7 @@ import DirectRequestForm from '@/components/DirectRequestForm';
 import type { MusicianSummary } from '@/types';
 import { fetchMusicianByUuid, generateAiText } from '@/lib/api/musicians';
 import { useUser } from '@/hooks/useUser';
+import { getToken } from '@/lib/auth';
 
 export default function MusicianDetailPage({
   params,
@@ -46,7 +47,7 @@ export default function MusicianDetailPage({
   const isOwner = user?.uuid === musician?.uuid;
 
   const handleGenerateAiText = async (trackUuid: string) => {
-    const token = localStorage.getItem('jwt');
+    const token = getToken();
     if (!token || !musician) return;
 
     setGeneratingTrackUuid(trackUuid);

--- a/frontend/src/app/requests/page.tsx
+++ b/frontend/src/app/requests/page.tsx
@@ -7,6 +7,7 @@ import AuthGuard from '@/components/AuthGuard';
 import DirectRequestCard from '@/components/DirectRequestCard';
 import type { DirectRequest } from '@/types';
 import { fetchDirectRequests } from '@/lib/api/directRequests';
+import { getToken, getStoredUser } from '@/lib/auth';
 
 export default function RequestsPage() {
   const router = useRouter();
@@ -16,18 +17,16 @@ export default function RequestsPage() {
   const [currentUserUuid, setCurrentUserUuid] = useState<string | null>(null);
 
   useEffect(() => {
-    const token = localStorage.getItem('jwt');
-    const userStr = localStorage.getItem('user');
-    if (!token || !userStr) return;
+    const token = getToken();
+    if (!token) return;
 
-    try {
-      const user = JSON.parse(userStr);
-      setCurrentUserUuid(user.uuid);
-    } catch {
+    const user = getStoredUser<{ uuid: string }>();
+    if (!user) {
       setError('ユーザー情報の取得に失敗しました');
       setLoading(false);
       return;
     }
+    setCurrentUserUuid(user.uuid);
 
     const load = async () => {
       try {

--- a/frontend/src/app/upload/page.tsx
+++ b/frontend/src/app/upload/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useState } from "react";
 import AuthGuard from "@/components/AuthGuard";
 import { useUser } from "@/hooks/useUser";
+import { getToken, handleSessionExpired } from "@/lib/auth";
 
 type AnalysisResult = {
   bpm?: number | null;
@@ -70,7 +71,7 @@ export default function UploadPage() {
     setUploadSuccess(false);
 
     try {
-      const token = localStorage.getItem("jwt");
+      const token = getToken();
       const formData = new FormData();
       formData.append("audio_file", audioFile);
 
@@ -83,8 +84,7 @@ export default function UploadPage() {
       });
 
       if (res.status === 401) {
-        localStorage.removeItem("jwt");
-        window.location.href = "/login";
+        handleSessionExpired();
         return;
       }
 
@@ -116,7 +116,7 @@ export default function UploadPage() {
     setUploadSuccess(false);
 
     try {
-      const token = localStorage.getItem("jwt");
+      const token = getToken();
       const res = await fetch(`${API}/api/v1/tracks`, {
         method: "POST",
         headers: {
@@ -127,8 +127,7 @@ export default function UploadPage() {
       });
 
       if (res.status === 401) {
-        localStorage.removeItem("jwt");
-        window.location.href = "/login";
+        handleSessionExpired();
         return;
       }
 

--- a/frontend/src/components/AuthGuard.tsx
+++ b/frontend/src/components/AuthGuard.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
+import { getToken } from "@/lib/auth";
 
 interface AuthGuardProps {
   children: React.ReactNode;
@@ -13,7 +14,7 @@ export default function AuthGuard({ children }: AuthGuardProps) {
   const pathname = usePathname();
 
   useEffect(() => {
-    const token = localStorage.getItem("jwt");
+    const token = getToken();
     if (!token) {
       router.replace(`/login?redirect=${encodeURIComponent(pathname)}`);
     } else {

--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useState, useRef, useEffect } from 'react';
 import { useChat } from '@/hooks/useChat';
 import { useUser } from '@/hooks/useUser';
+import { getToken } from '@/lib/auth';
 
 interface ChatBoxProps {
   conversationUuid: string;
@@ -11,8 +12,7 @@ interface ChatBoxProps {
 
 export default function ChatBox({ conversationUuid }: ChatBoxProps) {
   const { user } = useUser();
-  const token =
-    typeof window !== 'undefined' ? localStorage.getItem('jwt') : null;
+  const token = getToken();
 
   const {
     messages,

--- a/frontend/src/components/ContactButton.tsx
+++ b/frontend/src/components/ContactButton.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { apiGet, apiPost } from '@/lib/api/client';
+import { getToken } from '@/lib/auth';
 
 interface ContactButtonProps {
   jobUuid: string;
@@ -30,7 +31,7 @@ export default function ContactButton({ jobUuid, clientUuid }: ContactButtonProp
     setNeedsLogin(false);
 
     try {
-      const token = localStorage.getItem('jwt');
+      const token = getToken();
       if (!token) {
         setNeedsLogin(true);
         throw new Error('ログインしてください');

--- a/frontend/src/components/DirectRequestCard.tsx
+++ b/frontend/src/components/DirectRequestCard.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import type { DirectRequest } from '@/types';
 import { acceptDirectRequest, rejectDirectRequest } from '@/lib/api/directRequests';
 import ConfirmDialog from '@/components/ui/ConfirmDialog';
+import { getToken } from '@/lib/auth';
 
 interface DirectRequestCardProps {
   request: DirectRequest;
@@ -35,7 +36,7 @@ export default function DirectRequestCard({
     setError(null);
 
     try {
-      const token = localStorage.getItem('jwt');
+      const token = getToken();
       if (!token) {
         throw new Error('ログインしてください');
       }
@@ -57,7 +58,7 @@ export default function DirectRequestCard({
     setError(null);
 
     try {
-      const token = localStorage.getItem('jwt');
+      const token = getToken();
       if (!token) {
         throw new Error('ログインしてください');
       }

--- a/frontend/src/components/DirectRequestForm.tsx
+++ b/frontend/src/components/DirectRequestForm.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { z } from 'zod';
 import { createDirectRequest } from '@/lib/api/directRequests';
+import { getToken } from '@/lib/auth';
 
 const directRequestSchema = z.object({
   title: z.string().min(1, 'タイトルを入力してください').max(100, '100文字以内で入力してください'),
@@ -35,7 +36,7 @@ export default function DirectRequestForm({ musicianUuid, musicianName }: Direct
     setNeedsLogin(false);
 
     try {
-      const token = localStorage.getItem('jwt');
+      const token = getToken();
       if (!token) {
         setNeedsLogin(true);
         throw new Error('ログインしてください');

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+import { getToken, getStoredUser, removeToken } from "@/lib/auth";
 
 interface UserInfo {
   uuid: string;
@@ -18,21 +19,16 @@ export default function Header() {
   const [user, setUser] = useState<UserInfo | null>(null);
 
   useEffect(() => {
-    const stored = localStorage.getItem("user");
-    const token = localStorage.getItem("jwt");
-    if (stored && token) {
-      try {
-        setUser(JSON.parse(stored));
-      } catch {
-        setUser(null);
-      }
+    const token = getToken();
+    if (token) {
+      setUser(getStoredUser<UserInfo>());
     } else {
       setUser(null);
     }
   }, [pathname]);
 
   const handleLogout = async () => {
-    const token = localStorage.getItem("jwt");
+    const token = getToken();
     const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
     try {
@@ -47,8 +43,7 @@ export default function Header() {
       // ログアウトAPIが失敗してもローカルはクリアする
     }
 
-    localStorage.removeItem("jwt");
-    localStorage.removeItem("user");
+    removeToken();
     setUser(null);
     router.push("/");
   };

--- a/frontend/src/components/ProposalCard.tsx
+++ b/frontend/src/components/ProposalCard.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useState } from 'react';
 import ConfirmDialog from '@/components/ui/ConfirmDialog';
+import { getToken } from '@/lib/auth';
 
 interface Proposal {
   uuid: string;
@@ -44,7 +45,7 @@ export default function ProposalCard({ proposal, onAccepted, onRejected }: Propo
     setError(null);
     setNeedsLogin(false);
 
-    const token = localStorage.getItem('jwt');
+    const token = getToken();
     if (!token) {
       setNeedsLogin(true);
       setError('ログインしてください');

--- a/frontend/src/components/ProposalForm.tsx
+++ b/frontend/src/components/ProposalForm.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useState } from 'react';
+import { getToken } from '@/lib/auth';
 
 interface ProposalFormProps {
   jobUuid: string;
@@ -26,7 +27,7 @@ export default function ProposalForm({ jobUuid }: ProposalFormProps) {
     setSuccess(null);
     setNeedsLogin(false);
 
-    const token = localStorage.getItem('jwt');
+    const token = getToken();
     if (!token) {
       setNeedsLogin(true);
       setError('ログインしてください');

--- a/frontend/src/hooks/useUser.ts
+++ b/frontend/src/hooks/useUser.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { getToken, getStoredUser } from '@/lib/auth';
 
 interface UserInfo {
   readonly uuid: string;
@@ -18,15 +19,9 @@ export function useUser(): UseUserResult {
   const [user, setUser] = useState<UserInfo | null>(null);
 
   useEffect(() => {
-    const stored = localStorage.getItem('user');
-    const token = localStorage.getItem('jwt');
-    if (stored && token) {
-      try {
-        setUser(JSON.parse(stored));
-      } catch {
-        setUser(null);
-      }
-    }
+    const token = getToken();
+    if (!token) return;
+    setUser(getStoredUser<UserInfo>());
   }, []);
 
   return {

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,16 +1,11 @@
+import { handleSessionExpired } from '../auth';
+
 // SSR (Server Component) では相対パスが使えないため、サーバー内部URLを使用
 // ブラウザ (Client Component) では空文字 → 相対パス → nginx/rewrites がプロキシ
 const API_URL =
   typeof window === 'undefined'
     ? (process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000')
     : (process.env.NEXT_PUBLIC_API_URL || '');
-
-function handleSessionExpired(): void {
-  if (typeof window !== 'undefined') {
-    localStorage.removeItem('jwt');
-    window.location.href = '/login';
-  }
-}
 
 async function parseResponse<T>(res: Response): Promise<T> {
   const text = await res.text();

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,30 @@
+const JWT_KEY = 'jwt';
+const USER_KEY = 'user';
+
+export function getToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(JWT_KEY);
+}
+
+export function removeToken(): void {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(JWT_KEY);
+  localStorage.removeItem(USER_KEY);
+}
+
+export function getStoredUser<T = unknown>(): T | null {
+  if (typeof window === 'undefined') return null;
+  const stored = localStorage.getItem(USER_KEY);
+  if (!stored) return null;
+  try {
+    return JSON.parse(stored) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function handleSessionExpired(): void {
+  if (typeof window === 'undefined') return;
+  removeToken();
+  window.location.href = '/login';
+}


### PR DESCRIPTION
## 問題

`localStorage.getItem('jwt')` がフロントエンド全体に20箇所以上散在。

- SSRチェックの有無が不統一（一部ファイルは `typeof window !== 'undefined'` あり、一部なし）
- セッション切れ時の401処理が各ファイルで異なる実装
- トークン管理方式の変更時に全ファイルを修正する必要がある

## 解決策

`frontend/src/lib/auth.ts` を新設し、全トークン操作を集約した。

```typescript
getToken()              // SSR安全なJWT取得
removeToken()           // JWT + user を一括削除
getStoredUser<T>()      // JSON.parse + try/catch を内包
handleSessionExpired()  // removeToken() + /login リダイレクト
```

## 変更ファイル

- `src/lib/auth.ts` — 新規作成
- `src/lib/api/client.ts` — `handleSessionExpired` を auth.ts からインポートに変更
- `src/hooks/useUser.ts` — `getToken()` / `getStoredUser()` を使用
- `src/components/` 7ファイル、`src/app/` 6ファイル — `localStorage.getItem('jwt')` → `getToken()` に統一

## テスト

- [ ] `npx tsc --noEmit` エラーなし
- [ ] ログイン・ログアウトが正常動作すること
- [ ] 401時に `/login` へリダイレクトされること
- [ ] SSRページでエラーが出ないこと