### PR TITLE
fix: メッセージ送信後のuuidがnullになりTypeErrorが発生する問題を修正

### DIFF
--- a/backend/app/models/message.rb
+++ b/backend/app/models/message.rb
@@ -4,6 +4,8 @@ class Message < ApplicationRecord
 
   validates :content, presence: true, length: { minimum: 1, maximum: 1000 }
 
+  before_create { self.uuid = SecureRandom.uuid }
+
   # UUID対応
   def to_param
     uuid

--- a/backend/spec/requests/api/v1/messages_spec.rb
+++ b/backend/spec/requests/api/v1/messages_spec.rb
@@ -179,6 +179,7 @@ RSpec.describe 'Api::V1::Messages', type: :request do
       msg_data = json['message']
 
       expect(msg_data).to have_key('uuid')
+      expect(msg_data['uuid']).not_to be_nil
       expect(msg_data).not_to have_key('id')
       expect(msg_data).to have_key('sender_uuid')
       expect(msg_data).not_to have_key('sender_id')

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -41,7 +41,7 @@ export function useChat(
   useEffect(() => {
     const first = messages[0];
     oldestUuidRef.current =
-      first && !first.uuid.startsWith('pending-') ? first.uuid : null;
+      first && first.uuid != null && !first.uuid.startsWith('pending-') ? first.uuid : null;
   }, [messages]);
 
   // 初回メッセージ読み込み


### PR DESCRIPTION
## 問題

本番環境で案件詳細画面の「メッセージを送る」から新規会話を作成後、
初回メッセージを送信すると Application error が発生していた。

```
Uncaught TypeError: Cannot read properties of null (reading 'startsWith')
    at page-69a740ebc598d353.js:1:2644
```

## 原因

Rails 7.0 は `INSERT` 後に `RETURNING "id"` のみ実行し、
プライマリキー以外の DB デフォルト列を取得しない。

`messages.uuid` 列は `DEFAULT gen_random_uuid()` で DB が自動生成する設計だったため、
`message.save` 後も Ruby オブジェクト上では `message.uuid = nil` のまま残る。

```
APIレスポンス: { "message": { "uuid": null, ... } }
                                         ↑ nil がそのまま返る
```

フロントエンドの `useChat.ts:44` で確定メッセージを受け取った際、
`messages[0].uuid` が `null` となり `null.startsWith('pending-')` が TypeError を起こしていた。

## 修正

### `backend/app/models/message.rb`（根本修正）

```ruby
before_create { self.uuid = SecureRandom.uuid }
```

DB デフォルトに依存せず、Rails 側で保存前に UUID を生成する。
これにより `save` 後の `message.uuid` が確実に非 nil になる。

### `frontend/src/hooks/useChat.ts`（防御的修正）

```typescript
// Before
first && !first.uuid.startsWith('pending-') ? first.uuid : null

// After
first && first.uuid != null && !first.uuid.startsWith('pending-') ? first.uuid : null
```

`first.uuid` が null の場合に `.startsWith()` を呼ばないガードを追加。

### `backend/spec/requests/api/v1/messages_spec.rb`

POST `/messages` のレスポンスで `uuid` が `null` でないことを明示検証するアサーションを追加。
今後の回帰を CI で検出できるようにする。

## テスト計画

- [ ] `bundle exec rspec spec/models/message_spec.rb spec/requests/api/v1/messages_spec.rb`
- [ ] 案件詳細ページの「メッセージを送る」ボタンから新規会話を作成し、初回メッセージを送信して TypeError が発生しないことを確認
- [ ] 2通目以降のメッセージ送信も正常動作することを確認