### PR TITLE
refactor: tracks_controller#createの音声解析処理をサービスに抽出

### DIFF
--- a/backend/app/controllers/api/v1/tracks_controller.rb
+++ b/backend/app/controllers/api/v1/tracks_controller.rb
@@ -163,46 +163,12 @@ class Api::V1::TracksController < ApplicationController
 
     # 音声ファイル解析の処理
     if audio_file
-      temp_path = Rails.root.join('tmp', 'uploads', audio_file.original_filename)
-      FileUtils.mkdir_p(File.dirname(temp_path))
-      File.write(temp_path, audio_file.read, mode: 'wb')
+      result = TrackAudioAnalysisService.call(user: current_user, audio_file: audio_file, title: title)
 
-      begin
-        result = AnalyzerRunner.call(temp_path.to_s)
-
-        if result[:error]
-          render json: { data: result }, status: :unprocessable_entity
-        else
-          # 解析成功時にTrackをDBに保存
-          # AnalyzerRunnerはJSON.parse(文字列キー) + merge(シンボルキー)の混在を返す
-          track = Track.new(
-            user_id: current_user.id,
-            title: title || File.basename(audio_file.original_filename, '.*'),
-            bpm: result[:bpm] || result["bpm"],
-            key: result[:key] || result["key"],
-            genre: result[:genre] || result["genre"]
-          )
-
-          if track.save
-            track.reload
-            render json: {
-              message: "楽曲を登録しました",
-              data: {
-                uuid: track.uuid,
-                bpm: track.bpm,
-                key: track.key,
-                genre: track.genre
-              }
-            }, status: :created
-          else
-            render json: { data: { error: track.errors.full_messages.join(", ") } }, status: :unprocessable_entity
-          end
-        end
-      rescue => e
-        Rails.logger.error("解析処理エラー: #{e.message}")
-        render json: { data: { error: "解析エラーが発生しました" } }, status: :internal_server_error
-      ensure
-        File.delete(temp_path) if File.exist?(temp_path)
+      if result.success?
+        render json: { message: result.message, data: result.data }, status: :created
+      else
+        render json: { data: { error: result.error } }, status: result.status
       end
     else
       render json: { data: { error: "音声ファイルまたはYouTube URLを指定してください" } }, status: :bad_request

--- a/backend/app/services/track_audio_analysis_service.rb
+++ b/backend/app/services/track_audio_analysis_service.rb
@@ -1,0 +1,69 @@
+class TrackAudioAnalysisService
+  Result = Struct.new(:success?, :message, :data, :error, :status, keyword_init: true)
+
+  def self.call(user:, audio_file:, title:)
+    new(user, audio_file, title).call
+  end
+
+  def initialize(user, audio_file, title)
+    @user = user
+    @audio_file = audio_file
+    @title = title
+    @temp_path = Rails.root.join('tmp', 'uploads', audio_file.original_filename)
+  end
+
+  def call
+    write_temp_file
+    result = AnalyzerRunner.call(temp_path.to_s)
+
+    # AnalyzerRunnerのエラー時ハッシュは常に{error: ...}のみを持つ前提で文字列だけ渡している
+    return failure(result[:error], :unprocessable_entity) if result[:error]
+
+    track = build_track(result)
+
+    if track.save
+      track.reload
+      success(track)
+    else
+      failure(track.errors.full_messages.join(", "), :unprocessable_entity)
+    end
+  rescue => e
+    Rails.logger.error("解析処理エラー: #{e.message}")
+    failure("解析エラーが発生しました", :internal_server_error)
+  ensure
+    File.delete(temp_path) if File.exist?(temp_path)
+  end
+
+  private
+
+  attr_reader :user, :audio_file, :title, :temp_path
+
+  def write_temp_file
+    FileUtils.mkdir_p(File.dirname(temp_path))
+    File.write(temp_path, audio_file.read, mode: 'wb')
+  end
+
+  def build_track(result)
+    # AnalyzerRunnerはJSON.parse(文字列キー)+ merge(シンボルキー)混在のハッシュを返すため両方参照する
+    Track.new(
+      user_id: user.id,
+      title: title || File.basename(audio_file.original_filename, '.*'),
+      bpm: result[:bpm] || result["bpm"],
+      key: result[:key] || result["key"],
+      genre: result[:genre] || result["genre"]
+    )
+  end
+
+  def success(track)
+    Result.new(
+      success?: true,
+      message: "楽曲を登録しました",
+      data: { uuid: track.uuid, bpm: track.bpm, key: track.key, genre: track.genre },
+      status: :created
+    )
+  end
+
+  def failure(message, status)
+    Result.new(success?: false, error: message, status: status)
+  end
+end

--- a/backend/spec/services/track_audio_analysis_service_spec.rb
+++ b/backend/spec/services/track_audio_analysis_service_spec.rb
@@ -1,0 +1,144 @@
+require 'rails_helper'
+
+RSpec.describe TrackAudioAnalysisService do
+  let(:user) { User.create!(email: 'musician@example.com', password: 'password123', name: 'Musician') }
+  let(:audio_file) { fixture_file_upload('test.wav', 'audio/wav') }
+
+  describe '.call' do
+    context 'when analysis succeeds' do
+      before do
+        allow(AnalyzerRunner).to receive(:call).and_return({
+          bpm: 120,
+          key: "C",
+          genre: "Pop",
+          file_path: "test.wav",
+          status: "success"
+        })
+      end
+
+      it 'creates a track owned by the user and returns success' do
+        result = described_class.call(user: user, audio_file: audio_file, title: 'My Track')
+
+        expect(result.success?).to be true
+        expect(result.message).to eq("楽曲を登録しました")
+        expect(result.data[:bpm]).to eq(120)
+        expect(result.data[:key]).to eq("C")
+        expect(result.data[:genre]).to eq("Pop")
+        expect(result.data[:uuid]).to be_present
+
+        created_track = Track.last
+        expect(created_track.user_id).to eq(user.id)
+        expect(created_track.title).to eq('My Track')
+      end
+
+      it 'uses the filename (without extension) as the default title when title is blank' do
+        result = described_class.call(user: user, audio_file: audio_file, title: nil)
+
+        expect(result.success?).to be true
+        expect(Track.last.title).to eq('test')
+      end
+
+      it 'deletes the temporary uploaded file afterward' do
+        described_class.call(user: user, audio_file: audio_file, title: 'My Track')
+
+        temp_path = Rails.root.join('tmp', 'uploads', audio_file.original_filename)
+        expect(File.exist?(temp_path)).to be false
+      end
+
+      it 'passes the written temp file path to AnalyzerRunner' do
+        described_class.call(user: user, audio_file: audio_file, title: 'My Track')
+
+        expect(AnalyzerRunner).to have_received(:call).with(a_string_ending_with('test.wav'))
+      end
+    end
+
+    context 'when AnalyzerRunner returns a string-keyed result (raw JSON.parse shape)' do
+      before do
+        allow(AnalyzerRunner).to receive(:call).and_return({
+          "bpm" => 98,
+          "key" => "Am",
+          "genre" => "Lo-fi",
+          "status" => "success"
+        })
+      end
+
+      it 'still reads bpm/key/genre via the defensive string-key fallback' do
+        result = described_class.call(user: user, audio_file: audio_file, title: 'My Track')
+
+        expect(result.success?).to be true
+        expect(result.data[:bpm]).to eq(98)
+        expect(result.data[:key]).to eq("Am")
+        expect(result.data[:genre]).to eq("Lo-fi")
+      end
+    end
+
+    context 'when analysis fails' do
+      before do
+        allow(AnalyzerRunner).to receive(:call).and_return({
+          error: "音楽解析に失敗しました。ファイル形式を確認してください。"
+        })
+      end
+
+      it 'returns a failure result without creating a track' do
+        result = nil
+
+        expect {
+          result = described_class.call(user: user, audio_file: audio_file, title: 'My Track')
+        }.not_to change(Track, :count)
+
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+        expect(result.error).to eq("音楽解析に失敗しました。ファイル形式を確認してください。")
+      end
+
+      it 'deletes the temporary uploaded file' do
+        described_class.call(user: user, audio_file: audio_file, title: 'My Track')
+
+        temp_path = Rails.root.join('tmp', 'uploads', audio_file.original_filename)
+        expect(File.exist?(temp_path)).to be false
+      end
+    end
+
+    context 'when the track fails to save' do
+      before do
+        allow(AnalyzerRunner).to receive(:call).and_return({ bpm: 120, key: "C", genre: "Pop", status: "success" })
+      end
+
+      it 'returns a failure result with the validation error' do
+        long_title = 'a' * 121
+
+        result = described_class.call(user: user, audio_file: audio_file, title: long_title)
+
+        expect(result.success?).to be false
+        expect(result.status).to eq(:unprocessable_entity)
+        expect(result.error).to be_present
+      end
+
+      it 'deletes the temporary uploaded file' do
+        long_title = 'a' * 121
+
+        described_class.call(user: user, audio_file: audio_file, title: long_title)
+
+        temp_path = Rails.root.join('tmp', 'uploads', audio_file.original_filename)
+        expect(File.exist?(temp_path)).to be false
+      end
+    end
+
+    context 'when AnalyzerRunner raises an unexpected error' do
+      before do
+        allow(AnalyzerRunner).to receive(:call).and_raise(StandardError.new('boom'))
+      end
+
+      it 'returns an internal_server_error failure and still cleans up the temp file' do
+        result = described_class.call(user: user, audio_file: audio_file, title: 'My Track')
+
+        expect(result.success?).to be false
+        expect(result.status).to eq(:internal_server_error)
+        expect(result.error).to eq("解析エラーが発生しました")
+
+        temp_path = Rails.root.join('tmp', 'uploads', audio_file.original_filename)
+        expect(File.exist?(temp_path)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 問題
`Api::V1::TracksController#create` が1メソッドで無関係な2つの処理(YouTube URL登録 / 音声ファイル解析)を担っており、音声解析側は一時ファイルI/O・Pythonサブプロセス実行(AnalyzerRunner)・DB保存・エラーハンドリングが1メソッドに混在し、45行・ネスト3階層に達していた。

## 原因
コントローラーアクションに手続き的なロジックが積み上がった状態で、責務の分離がされていなかった。

## 対応
- `TrackAudioAnalysisService` を新規作成し、音声解析分岐のロジックを移植
  - 既存の `ProposalAcceptanceService` と同じ規約(`self.call` + `Result`構造体 + private `success`/`failure`ファクトリ)に統一
- YouTube URL登録分岐は単一モデルへの単純なCRUDのため、サービス化せず現状のままcontrollerに残置(このリポジトリのService層導入基準: 複数モデルにまたがる複雑な更新/外部連携/10-20行超の手続きコードのみ切り出す)
- レスポンスJSON形状・HTTPステータス・一時ファイル削除タイミングは完全に維持(挙動変更なし)
- `TrackAudioAnalysisService` の単体スペックを新規追加(成功/文字列キーフォールバック/解析失敗/保存失敗/例外発生の各パスと一時ファイル削除を検証)

`create` アクションは78行→44行に縮小。

## Test plan
- [x] `bundle exec rspec spec/services/track_audio_analysis_service_spec.rb` — 10例 pass
- [x] `bundle exec rspec spec/controllers/api/v1/tracks_controller_spec.rb spec/requests/api/v1/tracks_spec.rb` — 既存37例 pass(レスポンス形状に変更がないことを確認)
- [x] `bundle exec rspec` — バックエンド全体403例 pass