### PR TITLE
refactor: Proposal関連のAPIクライアント層統合 + 開発環境のAPI疎通修正

### DIFF
--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -64,4 +64,8 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # Docker Compose のサービス名 (backend) 経由のリクエスト(フロントエンドの
+  # Server Component からの内部通信)を許可する
+  config.hosts << "backend"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - "3001:3001"
     environment:
       NEXT_PUBLIC_API_URL: http://localhost:3000
+      API_INTERNAL_URL: http://backend:3000
     volumes:
       - ./frontend:/app
       - frontend_node_modules:/app/node_modules

--- a/frontend/src/app/jobs/[id]/proposals/page.tsx
+++ b/frontend/src/app/jobs/[id]/proposals/page.tsx
@@ -5,20 +5,10 @@ import { use, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import AuthGuard from '@/components/AuthGuard';
 import ProposalCard from '@/components/ProposalCard';
+import type { Proposal } from '@/types';
+import { fetchProposals } from '@/lib/api/proposals';
+import { fetchJob } from '@/lib/api/jobs';
 import { getToken } from '@/lib/auth';
-
-interface Proposal {
-  uuid: string;
-  quote_total_jpy: number;
-  delivery_days: number;
-  cover_message: string | null;
-  status: string;
-  created_at: string;
-  musician: {
-    uuid: string;
-    name: string;
-  };
-}
 
 interface JobSummary {
   uuid: string;
@@ -40,32 +30,18 @@ export default function ProposalsPage({ params }: { params: Promise<{ id: string
       if (!token) return;
 
       try {
-        const apiUrl = process.env.NEXT_PUBLIC_API_URL || '';
-
-        const [proposalsRes, jobRes] = await Promise.all([
-          fetch(`${apiUrl}/api/v1/jobs/${id}/proposals`, {
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: token,
-            },
-            cache: 'no-store',
-          }),
-          fetch(`${apiUrl}/api/v1/jobs/${id}`, {
-            cache: 'no-store',
-          }),
+        const [proposalsResult, jobResult] = await Promise.allSettled([
+          fetchProposals(token, id),
+          fetchJob(id),
         ]);
 
-        if (!proposalsRes.ok) {
-          const data = await proposalsRes.json();
-          throw new Error(data.error || '提案一覧の取得に失敗しました');
+        if (proposalsResult.status === 'rejected') {
+          throw proposalsResult.reason;
         }
+        setProposals(proposalsResult.value);
 
-        const proposalsData = await proposalsRes.json();
-        setProposals(proposalsData.proposals || []);
-
-        if (jobRes.ok) {
-          const jobData = await jobRes.json();
-          setJob({ uuid: jobData.job.uuid, title: jobData.job.title });
+        if (jobResult.status === 'fulfilled') {
+          setJob({ uuid: jobResult.value.uuid, title: jobResult.value.title });
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : '不明なエラーが発生しました');

--- a/frontend/src/components/ProposalCard.tsx
+++ b/frontend/src/components/ProposalCard.tsx
@@ -1,22 +1,10 @@
 'use client';
 
-import Link from 'next/link';
 import { useState } from 'react';
+import type { Proposal } from '@/types';
+import { acceptProposal, rejectProposal } from '@/lib/api/proposals';
 import ConfirmDialog from '@/components/ui/ConfirmDialog';
 import { getToken } from '@/lib/auth';
-
-interface Proposal {
-  uuid: string;
-  quote_total_jpy: number;
-  delivery_days: number;
-  cover_message: string | null;
-  status: string;
-  musician: {
-    uuid: string;
-    name: string;
-  };
-  created_at: string;
-}
 
 interface ProposalCardProps {
   proposal: Proposal;
@@ -24,7 +12,7 @@ interface ProposalCardProps {
   onRejected: (proposalUuid: string) => void;
 }
 
-const STATUS_LABELS: Record<string, { label: string; color: string }> = {
+const STATUS_LABELS: Record<Proposal['status'], { label: string; color: string }> = {
   submitted: { label: '審査中', color: 'bg-yellow-100 text-yellow-800' },
   shortlisted: { label: '候補', color: 'bg-blue-100 text-blue-800' },
   accepted: { label: '承諾済み', color: 'bg-green-100 text-green-800' },
@@ -35,48 +23,25 @@ const STATUS_LABELS: Record<string, { label: string; color: string }> = {
 export default function ProposalCard({ proposal, onAccepted, onRejected }: ProposalCardProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [needsLogin, setNeedsLogin] = useState(false);
   const [showRejectConfirm, setShowRejectConfirm] = useState(false);
   const isPending = proposal.status === 'submitted' || proposal.status === 'shortlisted';
-  const statusInfo = STATUS_LABELS[proposal.status] ?? { label: proposal.status, color: 'bg-gray-100 text-gray-800' };
+  const statusInfo = STATUS_LABELS[proposal.status];
 
   const handleAction = async (action: 'accept' | 'reject') => {
     setLoading(true);
     setError(null);
-    setNeedsLogin(false);
-
-    const token = getToken();
-    if (!token) {
-      setNeedsLogin(true);
-      setError('ログインしてください');
-      setLoading(false);
-      return;
-    }
 
     try {
-      const apiUrl = process.env.NEXT_PUBLIC_API_URL || '';
-      const res = await fetch(`${apiUrl}/api/v1/proposals/${proposal.uuid}/${action}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: token,
-        },
-      });
-
-      if (!res.ok) {
-        const data = await res.json();
-        const message = data.error || data.errors?.join(', ') || '操作に失敗しました';
-        if (res.status === 401 || message.toLowerCase().includes('signature has expired')) {
-          setNeedsLogin(true);
-          throw new Error('ログインセッションが切れました。再度ログインしてください');
-        }
-        throw new Error(message);
+      const token = getToken();
+      if (!token) {
+        throw new Error('ログインしてください');
       }
 
-      const data = await res.json();
       if (action === 'accept') {
+        const data = await acceptProposal(token, proposal.uuid);
         onAccepted(data.conversation_uuid);
       } else {
+        await rejectProposal(token, proposal.uuid);
         onRejected(proposal.uuid);
       }
     } catch (err) {
@@ -152,14 +117,7 @@ export default function ProposalCard({ proposal, onAccepted, onRejected }: Propo
       )}
 
       {error && (
-        <div className="rounded-lg bg-red-50 p-3 text-sm text-red-800">
-          <p>{error}</p>
-          {needsLogin && (
-            <Link href="/login" className="mt-1 inline-block text-red-600 underline hover:text-red-800">
-              ログインページへ
-            </Link>
-          )}
-        </div>
+        <div className="rounded-lg bg-red-50 p-3 text-sm text-red-800">{error}</div>
       )}
     </div>
   );

--- a/frontend/src/components/ProposalForm.tsx
+++ b/frontend/src/components/ProposalForm.tsx
@@ -2,14 +2,11 @@
 
 import Link from 'next/link';
 import { useState } from 'react';
+import { createProposal } from '@/lib/api/proposals';
 import { getToken } from '@/lib/auth';
 
 interface ProposalFormProps {
   jobUuid: string;
-}
-
-function isAuthError(status: number, message: string): boolean {
-  return status === 401 || message.toLowerCase().includes('signature has expired');
 }
 
 export default function ProposalForm({ jobUuid }: ProposalFormProps) {
@@ -36,38 +33,11 @@ export default function ProposalForm({ jobUuid }: ProposalFormProps) {
 
     setLoading(true);
     try {
-      const apiUrl = process.env.NEXT_PUBLIC_API_URL || '';
-      const res = await fetch(`${apiUrl}/api/v1/jobs/${jobUuid}/proposals`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: token,
-        },
-        body: JSON.stringify({
-          proposal: {
-            quote_total_jpy: Number(quoteTotalJpy),
-            delivery_days: Number(deliveryDays),
-            cover_message: coverMessage,
-          },
-        }),
+      await createProposal(token, jobUuid, {
+        quote_total_jpy: Number(quoteTotalJpy),
+        delivery_days: Number(deliveryDays),
+        cover_message: coverMessage,
       });
-
-      if (!res.ok) {
-        const text = await res.text();
-        let message = `応募に失敗しました (${res.status})`;
-        try {
-          const data = JSON.parse(text);
-          message = data.error || data.errors?.join(', ') || message;
-        } catch {
-          if (text) message = text;
-        }
-
-        if (isAuthError(res.status, message)) {
-          setNeedsLogin(true);
-          throw new Error('ログインセッションが切れました。再度ログインしてください');
-        }
-        throw new Error(message);
-      }
 
       setSuccess('応募が完了しました');
       setQuoteTotalJpy('');

--- a/frontend/src/lib/api/proposals.ts
+++ b/frontend/src/lib/api/proposals.ts
@@ -1,0 +1,49 @@
+import type {
+  Proposal,
+  ProposalCreatePayload,
+  ProposalsListResponse,
+  ProposalAcceptResponse,
+} from '@/types';
+import { apiGet, apiPost } from './client';
+
+export async function createProposal(
+  token: string,
+  jobUuid: string,
+  payload: ProposalCreatePayload
+): Promise<Proposal> {
+  const data = await apiPost<{ proposal: Proposal }>(
+    `/api/v1/jobs/${jobUuid}/proposals`,
+    token,
+    { proposal: payload }
+  );
+  return data.proposal;
+}
+
+export async function fetchProposals(
+  token: string,
+  jobUuid: string
+): Promise<Proposal[]> {
+  const data = await apiGet<ProposalsListResponse>(
+    `/api/v1/jobs/${jobUuid}/proposals`,
+    token
+  );
+  return data.proposals;
+}
+
+export async function acceptProposal(
+  token: string,
+  uuid: string
+): Promise<ProposalAcceptResponse> {
+  return apiPost<ProposalAcceptResponse>(`/api/v1/proposals/${uuid}/accept`, token);
+}
+
+export async function rejectProposal(
+  token: string,
+  uuid: string
+): Promise<Proposal> {
+  const data = await apiPost<{ proposal: Proposal }>(
+    `/api/v1/proposals/${uuid}/reject`,
+    token
+  );
+  return data.proposal;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -189,6 +189,48 @@ export type DirectRequestDetailResponse = {
 };
 
 /**
+ * 提案型
+ */
+export type Proposal = {
+  uuid: string;
+  job_uuid: string;
+  musician: {
+    uuid: string;
+    name: string;
+  };
+  quote_total_jpy: number;
+  delivery_days: number;
+  cover_message: string | null;
+  status: 'submitted' | 'shortlisted' | 'accepted' | 'rejected' | 'withdrawn';
+  created_at: string;
+};
+
+/**
+ * 提案作成ペイロード型
+ */
+export type ProposalCreatePayload = {
+  quote_total_jpy: number;
+  delivery_days: number;
+  cover_message: string;
+};
+
+/**
+ * Proposals一覧取得APIのレスポンス型
+ */
+export type ProposalsListResponse = {
+  proposals: Proposal[];
+};
+
+/**
+ * Proposal承諾APIのレスポンス型
+ */
+export type ProposalAcceptResponse = {
+  proposal: Proposal;
+  contract_uuid: string;
+  conversation_uuid: string;
+};
+
+/**
  * APIエラーレスポンス型
  */
 export type ApiErrorResponse = {


### PR DESCRIPTION
## 概要

- ProposalCard/ProposalFormが生fetchを直接実装し、認証エラー処理を個別に再実装していた問題を、既存のDirectRequest関連と同じパターン(`lib/api`配下のラッパー + 共通型定義)に統合
- 開発環境のdocker composeで、Server Component(SSR)からのAPI疎通が失敗していた問題を修正

## 変更内容

### 1. Proposal APIクライアント層統合(refactor)

**問題**: `ProposalCard.tsx`/`ProposalForm.tsx`/`proposals/page.tsx` がそれぞれ独自に`fetch()`を直書きし、401(セッション切れ)判定ロジックを個別に再実装していた。`Proposal`型も3箇所で重複定義。

**原因**: 既存の型安全なAPIクライアント層(`src/lib/api/client.ts`)を経由せず実装されていた。同じドメインパターンを持つ`DirectRequest`関連は既に正しくこのパターンに従っていた。

**修正**:
- `src/types/index.ts` に `Proposal`/`ProposalCreatePayload`/`ProposalsListResponse`/`ProposalAcceptResponse` を追加
- `src/lib/api/proposals.ts` を新規作成(`createProposal`/`fetchProposals`/`acceptProposal`/`rejectProposal`)
- `ProposalCard.tsx`/`ProposalForm.tsx`/`proposals/page.tsx` を上記経由に変更

### 2. 開発環境のAPI疎通修正(fix)

**問題**: `/jobs` など Server Component のページで「案件の取得に失敗しました」というエラーが発生。

**原因**:
1. `docker-compose.yml` に`API_INTERNAL_URL`が未設定で、SSR時のfetchが`localhost:3000`(frontendコンテナ自身)を向いており、backendコンテナに到達できなかった
2. 上記を`http://backend:3000`に向けても、RailsのHost Authorizationが`Host: backend:3000`ヘッダーを403でブロックしていた

**修正**:
- `docker-compose.yml`: `API_INTERNAL_URL: http://backend:3000` を追加(本番用composeには既存)
- `backend/config/environments/development.rb`: `config.hosts << "backend"` を追加

## Test plan

- [x] `npx tsc --noEmit` / `npm run lint` エラー0件
- [x] Docker実環境(DB migrate + seed)でbackend/frontendを起動し、curlでフロントエンドが呼ぶのと同一エンドポイントを実際に検証
  - [x] 提案作成(成功/重複エラー) — レスポンス形状が型定義と一致
  - [x] 提案一覧取得
  - [x] 承諾(`contract_uuid`/`conversation_uuid`が返る)
  - [x] 拒否(成功/ビジネスルールエラー)
  - [x] 不正トークンでの401
- [x] `/jobs`ページで「5件の案件」が正常表示されることを確認(修正前は「案件の取得に失敗しました」)
- [x] トップページ・案件詳細ページなど他のServer Componentページにも同様の問題がないことを確認
- [ ] ブラウザでの実際のクリック操作(承諾ボタン・拒否確認ダイアログ・トースト表示)は未実施のため、レビュー時に確認をお願いします